### PR TITLE
Distrobutable via Nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ DerivedData/
 ## Gcc Patch
 /*.gcno
 transcriber
+
+.direnv/

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,3 @@
+# Build the transcribe binary
+build:
+	swiftc -o transcriber transcribe/main.swift

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711124224,
+        "narHash": "sha256-l0zlN/3CiodvWDtfBOVxeTwYSRz93muVbXWSpaMjXxM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "56528ee42526794d413d6f244648aaee4a7b56c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "aarch64-darwin"
+      ];
+      perSystem = { config, pkgs, ... }:
+        let
+          # frameworks = pkgs.swift.apple_sdk.frameworks;
+          frameworks = pkgs.swiftPackages.apple_sdk.frameworks;
+          transcribe = pkgs.callPackage ./package.nix { };
+        in
+        {
+          packages = {
+            inherit transcribe;
+            default = transcribe;
+          };
+          devShells.default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              pkgs.swiftPackages.swift
+            ];
+            buildInputs = with pkgs; [
+              just
+              frameworks.Foundation
+              frameworks.Speech
+              frameworks.AVFoundation
+            ];
+          };
+        };
+    };
+}


### PR DESCRIPTION
I wish to create a distributed package using `nix`

If successful anyone with `nix` installed on their machine the would be able to:

```sh
# install globally
nix profile install github:dtinth/transcribe

# use without installing
rec -b 16 -c 1 -t raw -e signed-integer - rate 16000 | nix run github:dtinth/transcribe
```

Added benefit is that you will get a reproducible development environment, and I can also generate a docker image in a second iteration.

Steps:
- Build the `transcribe` using nix build deps
- Create a nix package that uses that environment to build
- Update README.md
- Open another PR for docker image